### PR TITLE
Install Xcode from Mac App Store

### DIFF
--- a/scripts/common/mac-app-store.sh
+++ b/scripts/common/mac-app-store.sh
@@ -1,0 +1,9 @@
+echo
+echo "Installing Mac App Store Command-line Interface"
+brew install mas
+echo "Installing Xcode"
+# new app store product ids can be found using
+# mas search Xcode
+mas install 497799835
+echo "Upgrading Outdated Apps"
+mas upgrade


### PR DESCRIPTION
not ready for merge

- [ ] decide whether to auto-upgrade apps installed by Mac App Store
- [ ] add `mac-app-store.sh` to main entrypoint
